### PR TITLE
Make bit_cast static and fix noexcept warning

### DIFF
--- a/runtime/globals.h
+++ b/runtime/globals.h
@@ -104,7 +104,7 @@ const word kHashImag = 1000003;
 #endif
 
 template <typename D, typename S>
-inline D bit_cast(const S& src) {
+static inline D bit_cast(const S& src) {
   static_assert(sizeof(S) == sizeof(D), "src and dst must be the same size");
   static_assert(IS_TRIVIALLY_COPYABLE(S), "src must be trivially copyable");
   static_assert(std::is_trivial<D>::value, "dst must be trivial");

--- a/util/freeze_modules.py
+++ b/util/freeze_modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.8
 # Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
 
 # Add library directory so we can import the compiler.


### PR DESCRIPTION
C++17 adds the exception specification to function types, which are part
of mangled symbol names, so make the name mangling problem go away by
making this function (which should always be inlined anyway) `static`.
Another alternative would be to add `noexcept`.

```
runtime/globals.h:107:10: error: mangled name for ‘D bit_cast(const S&) [with D = void*; S = void* (*)(void*, int, long unsigned int) throw ()]’ will change in C++17 because the exception specification is part of a function type [-Werror=noexcept-type]
 inline D bit_cast(const S& src) {
```