### PR TITLE
Make util/freeze_modules.py use a specific Python version

### DIFF
--- a/util/freeze_modules.py
+++ b/util/freeze_modules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.8
 # Copyright (c) Facebook, Inc. and its affiliates. (http://www.facebook.com)
 
 # Add library directory so we can import the compiler.


### PR DESCRIPTION
For bootstrapping, we need to make sure that the host Python compiler is
the same version that we target. Require Python 3.8 in bootstrapping.