### PR TITLE
Initialize small argument arrays in C-API trampolines

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,6 +11,8 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
+    - name: Install Python 3.8
+      run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
@@ -50,6 +52,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Install Python 3.8
+      run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
 
     - name: Configure CMake
@@ -115,6 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, build-prev]
     steps:
+    - name: Install Python 3.8
+      run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   build-prev:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-    - name: Install Python 3.8
-      run: sudo apt install -y python3.8
+      # - name: Install Python 3.8
+      #   run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
@@ -49,11 +49,11 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
-    - name: Install Python 3.8
-      run: sudo apt install -y python3.8
+      # - name: Install Python 3.8
+      #   run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
 
     - name: Configure CMake
@@ -116,11 +116,11 @@ jobs:
 
   benchmark:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [build, build-prev]
     steps:
-    - name: Install Python 3.8
-      run: sudo apt install -y python3.8
+      # - name: Install Python 3.8
+      #   run: sudo apt install -y python3.8
     - uses: actions/checkout@v3
       with:
         fetch-depth: 1
@@ -172,7 +172,7 @@ jobs:
           })
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # TODO(max): Install and run Black on Python code
     steps:
     - name: Install clang-format

--- a/ext/Internal/capi-trampolines.cpp
+++ b/ext/Internal/capi-trampolines.cpp
@@ -463,7 +463,7 @@ RawObject methodTrampolineFast(Thread* thread, word nargs) {
   Object self(&scope, thread->stackPeek(nargs - 1));
   word num_positional = nargs - 1;
 
-  PyObject* small_array[kMaxStackArguments];
+  PyObject* small_array[kMaxStackArguments] = {};
   PyObject** args;
   if (num_positional <= kMaxStackArguments) {
     args = small_array;
@@ -505,7 +505,7 @@ RawObject methodTrampolineFastKw(Thread* thread, word nargs) {
   Object self(&scope, thread->stackPeek(nargs));
   word num_positional = nargs - 1;
 
-  PyObject* small_array[kMaxStackArguments];
+  PyObject* small_array[kMaxStackArguments] = {};
   PyObject** args;
   if (num_positional <= kMaxStackArguments) {
     args = small_array;
@@ -556,7 +556,7 @@ RawObject methodTrampolineFastEx(Thread* thread, word flags) {
   Object self(&scope, args_tuple.at(0));
   word num_positional = args_length - 1;
 
-  PyObject* small_array[kMaxStackArguments];
+  PyObject* small_array[kMaxStackArguments] = {};
   PyObject** args;
   if (num_positional <= kMaxStackArguments) {
     args = small_array;


### PR DESCRIPTION
We always initialize these but the compiler can't prove that, I guess:

```
/home/runner/work/skybison/skybison/ext/Internal/capi-trampolines.cpp: In function ‘py::RawObject py::methodTrampolineFast(py::Thread*, word)’:
/home/runner/work/skybison/skybison/ext/Internal/capi-trampolines.cpp:480:75: error: ‘small_array’ may be used uninitialized [-Werror=maybe-uninitialized]
  480 |                 callMethFast(thread, function, self, args, num_positional));
      |                                                                           ^
/home/runner/work/skybison/skybison/ext/Internal/capi-trampolines.cpp:439:18: note: by argument 4 of type ‘PyObject* const*’ {aka ‘_object* const*’} to ‘py::RawObject py::callMethFast(py::Thread*, const Function&, const Object&, PyObject* const*, word)’ declared here
  439 | static RawObject callMethFast(Thread* thread, const Function& function,
      |                  ^~~~~~~~~~~~
/home/runner/work/skybison/skybison/ext/Internal/capi-trampolines.cpp:466:13: note: ‘small_array’ declared here
  466 |   PyObject* small_array[kMaxStackArguments];
      |             ^~~~~~~~~~~
```

Initialize them. This is hopefully not a noticeable performance hit.