### PR TITLE
Add django_minimal benchmark

### DIFF
--- a/benchmarks/benchmarks/django/benchmark.py
+++ b/benchmarks/benchmarks/django/benchmark.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+import argparse
+import atexit
+import http.client
+import json
+import logging
+import os
+import re
+import shlex
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import nullcontext
+
+
+# Do not change these without changing the bundled django_minimal run.py
+# TODO(emacs): Pass this through to run.py via a CLI argument
+host = "127.0.0.1"
+port = 8000
+
+
+def gitroot():
+    return subprocess.check_output(
+        ["git", "rev-parse", "--show-toplevel"], encoding="utf-8"
+    ).strip()
+
+
+def default_django_dir():
+    default_django_dir = "/var/tmp/django_minimal"
+    if os.path.exists(default_django_dir):
+        logging.info(f"django-dir: {default_django_dir}")
+        return default_django_dir
+    sys.stderr.write(
+        f"""Error: {default_django_dir} does not exist.
+
+You can probably fix this with:
+    mkdir -p {default_django_dir}
+    cd {default_django_dir}
+    {gitroot()}/benchmarks/benchmarks/django/setup_django_minimal.sh
+
+or by providing --django-dir to benchmark.py
+"""
+    )
+    sys.exit(1)
+
+
+def default_interpreter():
+    candidates = []
+    try:
+        root = gitroot()
+        candidates = (
+            f"{root}/build-release/python",
+            f"{root}/build/python",
+        )
+        candidates = [os.path.realpath(p) for p in candidates]
+        for p in candidates:
+            if os.path.exists(p):
+                logging.info(f"interpreter: {p}")
+                return p
+    except subprocess.CalledProcessError:
+        pass
+    sys.stderr.write(
+        f"""Error: Could not find interpreter in {candidates}
+Use --interpreter to specify manually.
+"""
+    )
+    sys.exit(1)
+
+
+def kill_server():
+    global server_process
+    if server_process is None:
+        return
+    if server_process.poll() is not None:
+        return
+    logging.info("Killing server...")
+    server_process.send_signal(subprocess.signal.SIGINT)
+    try:
+        server_process.wait(10)
+    except subprocess.TimeoutExpired:
+        server_process.send_signal(subprocess.signal.SIGKILL)
+        sys.stderr.write("Warning: Failed to shut down server, sending SIGKILL")
+
+
+def start_server(args, instr_atstart, callgrind_out_dir):
+    env = dict(os.environ)
+    env["PYTHONHASHSEED"] = "0"
+    cmd = [args.interpreter, *args.interpreter_args, "run.py"]
+    assert not (args.callgrind and args.bolt_record)
+    if args.callgrind:
+        valgrind_cmd = [
+            "valgrind",
+            "--tool=callgrind",
+            f"--callgrind-out-file={callgrind_out_dir}/cg",
+            "--dump-instr=yes",
+            "--collect-jumps=yes",
+        ]
+        if not instr_atstart:
+            valgrind_cmd += ["--instr-atstart=no"]
+        cmd = valgrind_cmd + cmd
+    elif args.bolt_record or args.perf_record:
+        perf_cmd = ["perf", "record", "-c", "9997", "-o", "perf.data"]
+        if args.bolt_record:
+            # Bolt want user-mode samples only, with last branch record active.
+            perf_cmd += ["-e", "cycles:u", "-j", "any,u", "--"]
+        else:
+            # For human consumption, we want to include kernel samples and
+            # stack traces.
+            perf_cmd += ["-e", "cycles", "-g", "--"]
+        cmd = perf_cmd + cmd
+
+    if os.path.exists("/bin/setarch"):
+        setarch = ["/bin/setarch", "x86_64", "--addr-no-randomize"]
+        if args.isolate_cpu is not None:
+            setarch += ["taskset", "--cpu-list", str(args.isolate_cpu)]
+        cmd = setarch + cmd
+    if args.server_log is not None:
+        logfile = args.server_log
+        logging.info(f">>> {' '.join(cmd)} >& {logfile}")
+        log_fp = open(logfile, "wb")  # noqa: P201
+        atexit.register(lambda: log_fp.close())
+    else:
+        log_fp = subprocess.DEVNULL
+    global server_process
+    logging.info(f"Running {shlex.join(cmd)}")
+    server_process = subprocess.Popen(
+        cmd, cwd=args.django_dir, env=env, stdout=log_fp, stderr=log_fp
+    )
+    atexit.register(kill_server)
+    timeout = 120 if not args.callgrind else 10000
+    logging.info("Waiting for open port...")
+    for _ in range(timeout):
+        time.sleep(1)
+        logging.info("Trying again...")
+        if server_process.poll() is not None:
+            logging.error("Error: Server unexpectedly quit")
+            sys.exit(1)
+        # Check if port is open yet...
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            if sock.connect_ex((host, port)) == 0:
+                break
+        finally:
+            sock.close()
+
+
+def extract_cg_instructions(filename):
+    try:
+        with open(filename) as fd:
+            r = re.compile(r"summary:\s*(.*)")
+            for line in fd:
+                m = r.match(line)
+                if m:
+                    return int(m.group(1))
+        logging.error(f"Could not determine cg_instruction count in {filename}")
+        sys.exit(1)
+    except FileNotFoundError as e:
+        raise Exception(
+            f"Could not find cg.XYZ files. Was the _valgrind module installed?"
+        ) from e
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--django-dir", default=None)
+    parser.add_argument("--no-server", default=False, action="store_true")
+    parser.add_argument("--interpreter", "-i", default=None)
+    parser.add_argument("--interpreter-args", default=(), type=shlex.split)
+    parser.add_argument("--callgrind", default=False, action="store_true")
+    parser.add_argument("--callgrind-out-dir")
+    parser.add_argument("--measure-startup", default=False, action="store_true")
+    parser.add_argument("--server-log", default=None)
+    parser.add_argument("--json", default=False, action="store_true")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--num-requests", "-n", default=None, type=int)
+    parser.add_argument("--bolt-record", default=False, action="store_true")
+    parser.add_argument("--perf-record", default=False, action="store_true")
+    parser.add_argument("--isolate-cpu")
+    args = parser.parse_args()
+    if args.callgrind + args.bolt_record + args.perf_record > 1:
+        raise RuntimeError(
+            "Only one of --bolt-record, --perf-record, and --callgrind "
+            "is supported at a time"
+        )
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARN, format="%(message)s"
+    )
+
+    if not args.no_server:
+        if args.django_dir is None:
+            args.django_dir = default_django_dir()
+        if args.interpreter is None:
+            args.interpreter = default_interpreter()
+
+    result_requests = {
+        "benchmark": f"django_minimal_requests",
+        "interpreter": args.interpreter,
+        "interpreter_args": args.interpreter_args,
+    }
+    result_startup = {
+        "benchmark": f"django_minimal_startup",
+        "interpreter": args.interpreter,
+        "interpreter_args": args.interpreter_args,
+    }
+
+    context = (
+        tempfile.TemporaryDirectory()
+        if args.callgrind_out_dir is None
+        else nullcontext(args.callgrind_out_dir)
+    )
+    with context as callgrind_out_dir:
+        os.makedirs(callgrind_out_dir, exist_ok=True)
+        if not args.no_server:
+            start_server(
+                args,
+                instr_atstart=args.measure_startup,
+                callgrind_out_dir=callgrind_out_dir,
+            )
+
+        if args.num_requests is None:
+            args.num_requests = 100 if not args.callgrind else 10
+
+        logging.info(f"Making {args.num_requests} requests...")
+        begin = time.perf_counter()
+        conn = http.client.HTTPConnection(host, port)
+        for i in range(0, args.num_requests):
+            conn.request("GET", "/hello/test")
+            response = conn.getresponse()
+            data = response.read()
+            if b"text=Hello&bottomtext=test" not in data:
+                raise RuntimeError(f"Invalid data: {data}")
+        conn.close()
+        end = time.perf_counter()
+        result_time = end - begin
+        logging.info(f"time: {int(result_time*1000)}ms")
+
+        if args.callgrind:
+            kill_server()
+
+            cg_instructions = extract_cg_instructions(f"{callgrind_out_dir}/cg.4")
+            result_requests["cg_instructions"] = cg_instructions
+            if args.measure_startup:
+                cg_instructions = extract_cg_instructions(f"{callgrind_out_dir}/cg.1")
+                result_startup["cg_instructions"] = cg_instructions
+        else:
+            result_requests["time_sec"] = result_time
+    if args.perf_record:
+        perf_data = f"{args.django_dir}/perf.data"
+        result_requests["perf_data"] = perf_data
+        result_startup["perf_data"] = perf_data
+        logging.info(
+            f"Wrote perf data. Open report with: perf report -i {args.django_dir}/perf.data"
+        )
+
+    result = [result_requests]
+    if args.measure_startup:
+        result += [result_startup]
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmarks/django/files/mysite/settings.py
+++ b/benchmarks/benchmarks/django/files/mysite/settings.py
@@ -1,0 +1,4 @@
+SECRET_KEY = "123456"
+DEBUG = True
+ROOT_URLCONF = "mysite.site"
+MIDDLEWARE = ["mysite.site.valgrind_middleware"]

--- a/benchmarks/benchmarks/django/files/mysite/site.py
+++ b/benchmarks/benchmarks/django/files/mysite/site.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+from django.conf.urls import url
+from django.http import HttpResponse
+
+
+try:
+    from _valgrind import callgrind_dump_stats, callgrind_start_instrumentation
+except ImportError:
+
+    def callgrind_dump_stats(description):
+        pass
+
+    def callgrind_start_instrumentation():
+        pass
+
+
+if os.environ.get("DJANGO_PROFILE"):
+    import _profiler
+
+    print("Enabling python profiling.")
+    _profiler.install()
+    profiler_dump = _profiler.dump_callgrind
+else:
+
+    def profiler_dump(filename):
+        pass
+
+
+try:
+    from _builtins import _gc
+
+    _gc()
+except ModuleNotFoundError:
+    pass
+
+
+def index(request):
+    return HttpResponse(
+        f'<html><body><img src="https://lookaside.internalfb.com/intern/macros/attachment/?fbid=1521180484640888&attachment_id=287065748458333" alt="it\'s alive">(powered by {sys.implementation.name})</body></html>'
+    )
+
+
+def hello(request, name):
+    return HttpResponse(
+        f'<html><body><img src="https://internalfb.com/intern/memes/image/?type=2849144811805277&text=Hello&bottomtext={name}">(powered by {sys.implementation.name})</body></html>'
+    )
+
+
+urlpatterns = [url(r"^hello/(?P<name>.*)$", hello), url("", index)]
+
+request_num = 0
+
+
+def valgrind_middleware(get_response):
+    def middleware(request):
+        global request_num
+        response = get_response(request)
+        callgrind_dump_stats(f"request_{request_num}")
+        profiler_dump(f"request_{request_num}.cg")
+        callgrind_start_instrumentation()
+        request_num += 1
+        return response
+
+    return middleware

--- a/benchmarks/benchmarks/django/files/run.py
+++ b/benchmarks/benchmarks/django/files/run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import mimetypes
+import os
+
+import django
+from django.conf import settings
+from django.core import management
+
+
+mimetypes.knownfiles = ["./mime.types"]
+
+
+os.environ["DJANGO_SETTINGS_MODULE"] = "mysite.settings"
+django.setup()
+management.call_command("runserver", use_reloader=False, use_threading=False)

--- a/benchmarks/benchmarks/django/setup_django_minimal.sh
+++ b/benchmarks/benchmarks/django/setup_django_minimal.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eu
+if [ "$(ls -A ".")" ]; then
+    echo "This script should be run in an empty writable directory"
+    exit 1
+fi
+
+set -x
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CURL_FLAGS="-L"
+# Setup devserver proxy config
+if hash fwdproxy-config 2>/dev/null; then
+    CURL_FLAGS="${CURL_FLAGS} $(fwdproxy-config curl)"
+fi
+for url in \
+    https://files.pythonhosted.org/packages/df/d5/3e3ff673e8f3096921b3f1b79ce04b832e0100b4741573154b72b756a681/pytz-2019.1.tar.gz \
+    https://files.pythonhosted.org/packages/63/c8/229dfd2d18663b375975d953e2bdc06d0eed714f93dcb7732f39e349c438/sqlparse-0.3.0.tar.gz \
+    https://files.pythonhosted.org/packages/2f/96/7d56b16388e8686ef8e2cb330204f247a90e6f008849dad7ce61c9c21c84/Django-1.11.22.tar.gz \
+
+do
+    archive="$(basename "${url}")"
+    if ! [ -e "$archive" ]; then
+        eval "curl ${CURL_FLAGS} -o ${archive} ${url}"
+    fi
+    tar -xzf "${archive}"
+done
+
+ln -s Django-1.11.22/django .
+ln -s pytz-2019.1/pytz .
+ln -s sqlparse-0.3.0/sqlparse .
+
+# Touch all the files, to give them a newer changed date. This helps people
+# installing django in /var/tmp as it tames aggressive devserver scripts
+# cleaning old files from /var/tmp.
+find . -print0 | xargs -0 touch
+
+# Copy patched mimes.type file.
+ln -sf "$SCRIPT_DIR/files/mysite" .
+cp "$SCRIPT_DIR/files/run.py" .

--- a/benchmarks/quickbench/benchmark_rev.py
+++ b/benchmarks/quickbench/benchmark_rev.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import sys
+
+from util import get_repo_root, normalize_revision, run, SCRIPT_PATH
+
+
+RESULTSDIR = "/var/tmp/benchresults"
+
+
+def benchmark(repo_root, revision, binary, resultsdir, args):
+    results = []
+    if args.run_django:
+        cgoutdir = f"{resultsdir}/cg/django"
+        run(["mkdir", "-p", cgoutdir])
+        cmd = [
+            f"{repo_root}/fbcode/pyro/experimental/django/benchmark.py",
+            "-i",
+            binary,
+            "--callgrind-out-dir",
+            cgoutdir,
+            "--json",
+            "--callgrind",
+        ]
+        proc = run(cmd, cwd="/", stdout=subprocess.PIPE, log_level=logging.INFO)
+        results += json.loads(proc.stdout)
+
+    if args.run_benchmarks:
+        cgoutdir = f"{resultsdir}/cg"
+        cmd = [
+            f"{repo_root}/fbcode/pyro/benchmarks/run.py",
+            "-i",
+            binary,
+            "-p",
+            f"{repo_root}/fbcode/pyro/benchmarks/benchmarks",
+            "--json",
+            "--tool=callgrind",
+            "--callgrind-out-dir",
+            cgoutdir,
+        ]
+        proc = run(cmd, cwd="/", stdout=subprocess.PIPE, log_level=logging.INFO)
+        results += json.loads(proc.stdout)
+
+    for result in results:
+        # Remove interpreter path as it unnecessarily produces
+        # differences because of changing temporary directories.
+        if "interpreter" in result:
+            del result["interpreter"]
+        result["interpreter_name"] = "pyro"
+        result["version"] = revision
+
+    return results
+
+
+if __name__ == "__main__":
+    description = "Checkout, build and benchmark a single revision"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("revision")
+    parser.add_argument(
+        "--ignore-cache", dest="check_cache", default=True, action="store_false"
+    )
+    parser.add_argument(
+        "--no-update-cache", dest="update_cache", default=True, action="store_false"
+    )
+    parser.add_argument(
+        "--only-cache", dest="only_cache", default=False, action="store_true"
+    )
+    parser.add_argument("--run-django", default=None, action="store_true")
+    parser.add_argument("--run-benchmarks", default=None, action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(format="%(message)s", level=log_level)
+
+    repo_root = get_repo_root(SCRIPT_PATH)
+
+    if args.run_django is None and args.run_benchmarks is None:
+        args.run_django = True
+
+    cache_env = (
+        open(__file__, "r").read()
+        + f"django: {args.run_django}"
+        + f"benchmarks: {args.run_benchmarks}"
+    )
+    cache_env_hash = hashlib.sha256(cache_env.encode()).hexdigest()[:8]
+
+    revision = normalize_revision(repo_root, args.revision)
+    resultsdir = f"{RESULTSDIR}/{revision}_{cache_env_hash}"
+    cachefile = f"{resultsdir}/result.json"
+
+    results = None
+    if args.check_cache:
+        try:
+            results = json.load(open(cachefile))
+            sys.stderr.write(f"Using cached results from {cachefile}\n")
+        except Exception:
+            pass
+
+    if results is None and not args.only_cache:
+        cmd = [f"{SCRIPT_PATH}/build_rev.py"]
+        if args.verbose:
+            cmd += ["--verbose"]
+        cmd += [revision]
+        p = run(cmd, stdout=subprocess.PIPE)
+        binary = p.stdout.strip()
+        if not binary.startswith("/"):
+            logging.critical(f"Build script did not produce a path. Output: {binary}")
+
+        results = benchmark(repo_root, revision, binary, resultsdir, args)
+        if args.update_cache and results:
+            try:
+                run(["mkdir", "-p", os.path.dirname(cachefile)])
+                with open(cachefile, "w") as fp:
+                    json.dump(results, fp=fp, indent=2, sort_keys=True)
+            except Exception:
+                logging.warning(f"Failed to save results to {cachefile}\n")
+
+    out = sys.stdout
+    json.dump(results, fp=out, indent=2, sort_keys=True)
+    out.write("\n")

--- a/benchmarks/quickbench/benchmark_rev.py
+++ b/benchmarks/quickbench/benchmark_rev.py
@@ -19,7 +19,7 @@ def benchmark(repo_root, revision, binary, resultsdir, args):
         cgoutdir = f"{resultsdir}/cg/django"
         run(["mkdir", "-p", cgoutdir])
         cmd = [
-            f"{repo_root}/fbcode/pyro/experimental/django/benchmark.py",
+            f"{repo_root}/benchmarks/benchmarks/django/benchmark.py",
             "-i",
             binary,
             "--callgrind-out-dir",
@@ -33,11 +33,11 @@ def benchmark(repo_root, revision, binary, resultsdir, args):
     if args.run_benchmarks:
         cgoutdir = f"{resultsdir}/cg"
         cmd = [
-            f"{repo_root}/fbcode/pyro/benchmarks/run.py",
+            f"{repo_root}/benchmarks/run.py",
             "-i",
             binary,
             "-p",
-            f"{repo_root}/fbcode/pyro/benchmarks/benchmarks",
+            f"{repo_root}/benchmarks/benchmarks",
             "--json",
             "--tool=callgrind",
             "--callgrind-out-dir",

--- a/benchmarks/quickbench/build_rev.py
+++ b/benchmarks/quickbench/build_rev.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+
+from util import get_repo_root, normalize_revision, run, SCRIPT_PATH
+
+
+KEEP_BUILDS = 15
+BUILDS_DIR = "/var/tmp/bench_builds"
+
+
+def find_binary(builddir):
+    candidates = (
+        f"{builddir}/bin/python",  # new revisions
+        f"{builddir}/python",  # older revisions
+    )
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+def find_cmake(repo_root):
+    tp2_cmake = (
+        f"{repo_root}/fbcode/third-party2/cmake/3.15.2/centos7-native/da39a3e/bin/cmake"
+    )
+    if sys.platform == "linux" and os.path.exists(tp2_cmake):
+        return tp2_cmake
+    return "cmake"
+
+
+def build(repo_root, builddir, sourcedir):
+    cmake_flags = [
+        "-S",
+        sourcedir,
+        "-B",
+        builddir,
+        f"-DCMAKE_TOOLCHAIN_FILE={sourcedir}/util/platform009-gcc.cmake",
+        "-DCMAKE_BUILD_TYPE=Release",
+    ]
+    run(
+        [find_cmake(repo_root), "-GNinja"] + cmake_flags,
+        stdout=subprocess.DEVNULL,
+        log_level=logging.INFO,
+    )
+    run(
+        ["ninja", "-C", builddir, "python"],
+        stdout=subprocess.DEVNULL,
+        log_level=logging.INFO,
+    )
+
+    binary = find_binary(builddir)
+    if binary is None:
+        logging.critical(f"No python binary found in {builddir}")
+        sys.exit(1)
+    return binary
+
+
+def checkout_and_build(repo_root, revision, builddir):
+    with tempfile.TemporaryDirectory(prefix="bench_") as tempdir:
+        workdir = f"{tempdir}/workdir"
+        run(
+            ["hg-new-workdir", "fbcode", workdir],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+        )
+        try:
+            run(["hg", "checkout", revision], cwd=workdir, stdout=subprocess.DEVNULL)
+
+            sourcedir = f"{workdir}/fbcode/pyro"
+            run(["mkdir", "-p", builddir], log_level=logging.DEBUG)
+            return build(repo_root, builddir, sourcedir)
+        finally:
+            run(["eden", "rm", "--no-prompt", workdir], stdout=subprocess.DEVNULL)
+
+
+def clean_old_builds():
+    builds = []
+    for entry in os.scandir(BUILDS_DIR):
+        stat = entry.stat()
+        builds.append((stat.st_mtime, entry.path))
+    builds.sort(reverse=True)
+    for _, old_build in builds[KEEP_BUILDS - 1 :]:
+        run(["rm", "-rf", old_build], log_level=logging.INFO)
+
+
+if __name__ == "__main__":
+    description = "Checkout and build a single revision"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--no-clean", action="store_true")
+    parser.add_argument("--no-cache", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("revision")
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(format="%(message)s", level=log_level)
+
+    repo_root = get_repo_root(SCRIPT_PATH)
+
+    cache_env = open(__file__, "r").read()
+    cache_env_hash = hashlib.sha256(cache_env.encode()).hexdigest()[:8]
+
+    run(["mkdir", "-p", BUILDS_DIR], log_level=logging.DEBUG)
+
+    revision = normalize_revision(repo_root, args.revision)
+    builddir = f"{BUILDS_DIR}/{revision}_{cache_env_hash}"
+    binary = None
+    if os.path.exists(builddir):
+        if args.no_cache:
+            run(["rm", "-rf", builddir], log_level=logging.INFO)
+        else:
+            binary = find_binary(builddir)
+            if binary is not None:
+                run(["touch", builddir])
+                print(binary)
+                sys.exit(0)
+            # Looks like an invalid/incomplete build, remove it.
+            run(["rm", "-rf", builddir], log_level=logging.INFO)
+
+    if not args.no_clean:
+        clean_old_builds()
+
+    if binary is None:
+        binary = checkout_and_build(repo_root, revision, builddir)
+
+    print(binary)

--- a/benchmarks/quickbench/diffrevs.py
+++ b/benchmarks/quickbench/diffrevs.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from collections import defaultdict
+
+from util import get_repo_root, normalize_revision, run, SCRIPT_PATH
+
+
+def run_benchmarks(revs, revnames, args):
+    rev_samples = []
+    for rev in revs:
+        cmd = [f"{SCRIPT_PATH}/benchmark_rev.py", *args.benchmark_rev_args, rev]
+        proc = run(cmd, stdout=subprocess.PIPE)
+        try:
+            samples = json.loads(proc.stdout)
+            rev_samples.append(samples)
+        except Exception:
+            sys.stderr.write(f"Failed to parse benchmark data:\n{proc.stdout}\n")
+            sys.exit(1)
+
+    return rev_samples
+
+
+def aggregate_results(rev_samples, revnames):  # noqa: C901
+    samples_per_benchmark = defaultdict(list)
+    for rev in rev_samples:
+        found_benchmarks = set()
+        for result in rev:
+            if "benchmark" not in result:
+                sys.stderr.write("Warning: result without benchmark name\n")
+                continue
+            benchmark = result["benchmark"]
+            if benchmark in found_benchmarks:
+                sys.stderr.write("Multiple results for same benchmark?\n")
+                continue
+            found_benchmarks.add(benchmark)
+            samples_per_benchmark[benchmark].append(result)
+
+    results = {}
+    for _benchmark, rev_samples in sorted(samples_per_benchmark.items()):
+        keys = set()
+        for samples in rev_samples:
+            keys.update(samples.keys())
+
+        bresults = {}
+        for key in keys:
+            all_same = True
+            common_value = None
+            values = []
+            for samples in rev_samples:
+                value = samples.get(key)
+                values.append(value)
+                if value is None:
+                    continue
+                if common_value is None:
+                    common_value = value
+                elif value != common_value:
+                    all_same = False
+            if all_same:
+                bresults[key] = common_value
+                continue
+            for revname, value in zip(revnames, values):
+                if value is None:
+                    continue
+                bresults[f"{key} {revname}"] = value
+
+        # Compute delta to rev0
+        samples0 = rev_samples[0]
+        for key, value0 in samples0.items():
+            if key in bresults:
+                continue
+            if not isinstance(value0, (float, int)) or value0 == 0:
+                continue
+            for revname, samples in zip(revnames[1:], rev_samples[1:]):
+                if key not in samples:
+                    continue
+                value1 = samples[key]
+                delta_key = f"{key} ∆" + ("" if len(revnames) == 2 else f" {revname}")
+                rel_delta = (value1 - value0) / float(value0)
+                bresults[delta_key] = f"{rel_delta * 100.:2.1f}%"
+        results[bresults["benchmark"]] = bresults
+    return results
+
+
+if __name__ == "__main__":
+    description = "Checkout, build, benchmark and compare multiple revisions"
+    epilog = f"""
+
+Example:
+    {sys.argv[0]} .~1 .              # compare parent with current revision
+"""
+    parser = argparse.ArgumentParser(description=description, epilog=epilog)
+    parser.add_argument("revisions", metavar="REVISION", nargs="+", default="")
+    parser.add_argument(
+        "--run-django",
+        dest="benchmark_rev_args",
+        default=[],
+        action="append_const",
+        const="--run-django",
+    )
+    parser.add_argument(
+        "--run-benchmarks",
+        dest="benchmark_rev_args",
+        action="append_const",
+        const="--run-benchmarks",
+    )
+    parser.add_argument(
+        "--ignore-cache",
+        dest="benchmark_rev_args",
+        action="append_const",
+        const="--ignore-cache",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(format="%(message)s", level=log_level)
+
+    if args.verbose:
+        args.benchmark_rev_args.insert(0, "--verbose")
+
+    if len(args.revisions) < 2:
+        parser.print_help()
+        sys.stdout.write("\n\nError: Need at least two revision numbers\n")
+        sys.exit(1)
+
+    repo_root = get_repo_root(SCRIPT_PATH)
+
+    revs = args.revisions
+    if len(revs) == 2:
+        revnames = ["before", "now"]
+    else:
+        revnames = [str(x) for x in range(len(revs))]
+    revs = [normalize_revision(repo_root, rev) for rev in revs]
+
+    rev_samples = run_benchmarks(revs, revnames, args)
+
+    results = aggregate_results(rev_samples, revnames)
+
+    out = sys.stdout
+    json.dump(results, fp=out, indent=2, sort_keys=True, ensure_ascii=False)
+    out.write("\n")

--- a/benchmarks/quickbench/util.py
+++ b/benchmarks/quickbench/util.py
@@ -17,19 +17,17 @@ def run(cmd, check=True, encoding="utf-8", log_level=logging.DEBUG, **kwargs):
 
 
 def get_repo_root(dirname):
-    completed_process = run(
-        ["hg", "root"], check=False, cwd=dirname, stdout=subprocess.PIPE
+    proc = run(
+        ["git", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE,
+        cwd=dirname,
     )
-    if completed_process.returncode == 0:
-        return completed_process.stdout.strip()
-
-    sys.stderr.write("Unknown source control\n")
-    sys.exit(1)
+    return proc.stdout.strip()
 
 
 def normalize_revision(repo_root, revspec):
     proc = run(
-        ["hg", "log", "-r", revspec, "--template", "{node}"],
+        ["git", "rev-parse", revspec],
         stdout=subprocess.PIPE,
         cwd=repo_root,
     )

--- a/benchmarks/quickbench/util.py
+++ b/benchmarks/quickbench/util.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import subprocess
+import sys
+
+
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+def run(cmd, check=True, encoding="utf-8", log_level=logging.DEBUG, **kwargs):
+    if "cwd" in kwargs:
+        log_msg = f"$ cd {kwargs['cwd']}; {' '.join(cmd)}"
+    else:
+        log_msg = f"$ {' '.join(cmd)}"
+    logging.log(log_level, log_msg)
+    return subprocess.run(cmd, check=check, encoding=encoding, **kwargs)
+
+
+def get_repo_root(dirname):
+    completed_process = run(
+        ["hg", "root"], check=False, cwd=dirname, stdout=subprocess.PIPE
+    )
+    if completed_process.returncode == 0:
+        return completed_process.stdout.strip()
+
+    sys.stderr.write("Unknown source control\n")
+    sys.exit(1)
+
+
+def normalize_revision(repo_root, revspec):
+    proc = run(
+        ["hg", "log", "-r", revspec, "--template", "{node}"],
+        stdout=subprocess.PIPE,
+        cwd=repo_root,
+    )
+    return proc.stdout.strip()

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -147,7 +147,8 @@ class Interpreter:
                 b = self.create_benchmark_from_file(path)
                 discovered_benchmarks.append(b)
             elif os.path.isdir(path) and (
-                "__pycache__" not in path and "data" not in path
+                "__pycache__" not in path and "data" not in path and "django"
+                not in path
             ):
                 b = self.create_benchmark_from_dir(path)
                 discovered_benchmarks.append(b)


### PR DESCRIPTION
Run:

```
$ mkdir /var/tmp/django_minimal
$ pushd /var/tmp/django_minimal
$ /path/to/skybison/checkout/benchmarks/benchmarks/django/setup_django_minimal.sh
$ popd
$ ./benchmarks/benchmarks/django/benchmark.py --django-dir /var/tmp/django_minimal/ --interpreter $(pwd)/build-relwithdebinfo/bin/python --callgrind --callgrind-out-dir $(pwd) --num-requests 10
[
  {
    "benchmark": "django_minimal_requests",
    "cg_instructions": 738721,
    "interpreter": "/home/max/Documents/code/skybison/build-relwithdebinfo/bin/python",
    "interpreter_args": []
  }
]
$ kcachegrind cg.4
```

Check out the callgrind files. See what's slow. Normally the server takes a couple requests to warm up. It does not profile interpreter startup by default and profiles separately per-request.

The JSON output's cg_instructions also has useful (and relatively stable) information and can be used as a proxy for runtime performance.