### PR TITLE
Rewrite LOAD_GLOBAL _Unbound to LOAD_IMMEDIATE in builtins module

### DIFF
--- a/runtime/bytecode.cpp
+++ b/runtime/bytecode.cpp
@@ -89,7 +89,8 @@ struct RewrittenOp {
   bool needs_inline_cache;
 };
 
-static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op) {
+static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op,
+                                    bool is_builtin_module) {
   auto cached_binop = [](Interpreter::BinaryOp bin_op) {
     return RewrittenOp{BINARY_OP_ANAMORPHIC, static_cast<int32_t>(bin_op),
                        true};
@@ -177,6 +178,20 @@ static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op) {
       return cached_inplace(Interpreter::BinaryOp::XOR);
     case LOAD_ATTR:
       return RewrittenOp{LOAD_ATTR_ANAMORPHIC, op.arg, true};
+    case LOAD_GLOBAL: {
+      if (is_builtin_module) {
+        RawTuple names = Tuple::cast(Code::cast(function.code()).names());
+        RawStr name = Str::cast(names.at(op.arg));
+        if (name.equalsCStr("_Unbound")) {
+          DCHECK(Unbound::object() ==
+                     objectFromOparg(opargFromObject(Unbound::object())),
+                 "Expected to be able to fit _Unbound in a byte");
+          return RewrittenOp{LOAD_IMMEDIATE, opargFromObject(Unbound::object()),
+                             false};
+        }
+      }
+      break;
+    }
     case LOAD_FAST: {
       CHECK(op.arg < Code::cast(function.code()).nlocals(),
             "unexpected local number");
@@ -291,7 +306,8 @@ void rewriteBytecode(Thread* thread, const Function& function) {
   word num_caches = num_global_caches;
   for (word i = 0; i < num_opcodes;) {
     BytecodeOp op = nextBytecodeOp(bytecode, &i);
-    RewrittenOp rewritten = rewriteOperation(function, op);
+    RewrittenOp rewritten = rewriteOperation(function, op,
+                                             /*is_builtin_module=*/false);
     if (rewritten.needs_inline_cache) {
       num_caches++;
     }
@@ -308,10 +324,13 @@ void rewriteBytecode(Thread* thread, const Function& function) {
     return;
   }
   word cache = num_global_caches;
+  RawObject module = function.moduleObject();
+  bool is_builtin_module =
+      module.isModule() && Module::cast(module).isBuiltin();
   for (word i = 0; i < num_opcodes;) {
     BytecodeOp op = nextBytecodeOp(bytecode, &i);
     word previous_index = i - 1;
-    RewrittenOp rewritten = rewriteOperation(function, op);
+    RewrittenOp rewritten = rewriteOperation(function, op, is_builtin_module);
     if (rewritten.bc == UNUSED_BYTECODE_0) continue;
     if (rewritten.needs_inline_cache) {
       rewrittenBytecodeOpAtPut(bytecode, previous_index, rewritten.bc);

--- a/runtime/modules.cpp
+++ b/runtime/modules.cpp
@@ -30,6 +30,7 @@ static RawObject createBuiltinModule(Thread* thread, const Str& name) {
   if (builtin_index >= 0) {
     const FrozenModule* frozen_module = &kFrozenModules[builtin_index];
     Module module(&scope, runtime->newModule(name));
+    module.setId(module.id() | RawModule::kBuiltinTag);
     Object modules(&scope, runtime->modules());
     Object result(&scope, objectSetItem(thread, modules, name, module));
     if (result.isErrorException()) return *result;

--- a/runtime/objects.h
+++ b/runtime/objects.h
@@ -2683,12 +2683,19 @@ class RawModule : public RawAttributeDict {
   word id() const;
   void setId(word id) const;
 
+  // Return true if the module is built-in; if so, the high bit of id is
+  // tagged.
+  bool isBuiltin() const;
+
   // Layout.
   static const int kNameOffset = RawAttributeDict::kSize;
   static const int kDefOffset = kNameOffset + kPointerSize;
   static const int kStateOffset = kDefOffset + kPointerSize;
   static const int kModuleProxyOffset = kStateOffset + kPointerSize;
   static const int kSize = kModuleProxyOffset + kPointerSize;
+
+  static const uword kBuiltinTag = uword{1} << sizeof(uword);
+  static const uword kBuiltinTagMask = ~kBuiltinTag;
 
   // Constants.
   static const word kMaxModuleId = RawHeader::kHashCodeMask;
@@ -7058,6 +7065,10 @@ inline void RawModule::setId(word id) const {
   DCHECK(static_cast<word>(id & RawHeader::kHashCodeMask) == id,
          "Module ID %ld doesn't fit in hash code", id);
   setHeader(header().withHashCode(id));
+}
+
+inline bool RawModule::isBuiltin() const {
+  return id() & kBuiltinTagMask;
 }
 
 // RawModuleProxy


### PR DESCRIPTION
This should save some caches and be faster. Ideally we would do this in
all Skybison-controlled modules but I don't think we have a good signal
for that yet.

Partially addresses #395