### PR TITLE
Add UNARY_NEGATIVE_SMALLINT

### DIFF
--- a/runtime/bytecode.cpp
+++ b/runtime/bytecode.cpp
@@ -98,6 +98,11 @@ static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op) {
     return RewrittenOp{INPLACE_OP_ANAMORPHIC, static_cast<int32_t>(bin_op),
                        true};
   };
+  auto cached_unop = [](Interpreter::UnaryOp unary_op) {
+    // TODO(emacs): Add caching for methods on non-smallints
+    return RewrittenOp{UNARY_OP_ANAMORPHIC, static_cast<int32_t>(unary_op),
+                       false};
+  };
   switch (op.bc) {
     case BINARY_ADD:
       return cached_binop(Interpreter::BinaryOp::ADD);
@@ -175,6 +180,9 @@ static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op) {
       return cached_inplace(Interpreter::BinaryOp::TRUEDIV);
     case INPLACE_XOR:
       return cached_inplace(Interpreter::BinaryOp::XOR);
+      // TODO(emacs): Fill in other unary ops
+    case UNARY_NEGATIVE:
+      return cached_unop(Interpreter::UnaryOp::NEGATIVE);
     case LOAD_ATTR:
       return RewrittenOp{LOAD_ATTR_ANAMORPHIC, op.arg, true};
     case LOAD_FAST: {
@@ -241,6 +249,7 @@ static RewrittenOp rewriteOperation(const Function& function, BytecodeOp op) {
     case LOAD_FAST_REVERSE:
     case LOAD_METHOD_ANAMORPHIC:
     case STORE_ATTR_ANAMORPHIC:
+    case UNARY_OP_ANAMORPHIC:
       UNREACHABLE("should not have cached opcode in input");
     default:
       break;

--- a/runtime/bytecode.h
+++ b/runtime/bytecode.h
@@ -24,8 +24,8 @@ namespace py {
   V(DUP_TOP, 4, doDupTop)                                                      \
   V(DUP_TOP_TWO, 5, doDupTopTwo)                                               \
   V(ROT_FOUR, 6, doRotFour)                                                    \
-  V(UNUSED_BYTECODE_7, 7, doInvalidBytecode)                                   \
-  V(UNUSED_BYTECODE_8, 8, doInvalidBytecode)                                   \
+  V(UNARY_OP_ANAMORPHIC, 7, doUnaryOpAnamorphic)                               \
+  V(UNARY_NEGATIVE_SMALLINT, 8, doUnaryNegativeSmallInt)                       \
   V(NOP, 9, doNop)                                                             \
   V(UNARY_POSITIVE, 10, doUnaryPositive)                                       \
   V(UNARY_NEGATIVE, 11, doUnaryNegative)                                       \

--- a/runtime/interpreter.h
+++ b/runtime/interpreter.h
@@ -67,6 +67,13 @@ class Interpreter {
     OR
   };
 
+  enum class UnaryOp {
+    NEGATIVE,
+    POSITIVE,
+    NOT,
+    INVERT,
+  };
+
   enum class Continue {
     NEXT,
     UNWIND,
@@ -484,7 +491,9 @@ class Interpreter {
   static Continue doStoreSubscrPolymorphic(Thread* thread, word arg);
   static Continue doStoreSubscrAnamorphic(Thread* thread, word arg);
   static Continue doUnaryInvert(Thread* thread, word arg);
+  static Continue doUnaryOpAnamorphic(Thread* thread, word arg);
   static Continue doUnaryNegative(Thread* thread, word arg);
+  static Continue doUnaryNegativeSmallInt(Thread* thread, word arg);
   static Continue doUnaryNot(Thread* thread, word arg);
   static Continue doUnaryPositive(Thread* thread, word arg);
   static Continue doUnpackEx(Thread* thread, word arg);


### PR DESCRIPTION
Don't make a monomorphic cache on failure, though; just look up the method as usual.

Without asm implementation:

```
  "nqueens": {
    "benchmark": "nqueens",
    "cg_instructions before": 3293749025,
    "cg_instructions now": 3207631962,
    "cg_instructions ∆": "-2.6%",
    "interpreter_name": "pyro",
    "version before": "80d8286edd5f6f19db0d5177b6490b89d9133765",
    "version now": "e0f0577d47ff5986029f885e5b502732238a3126"
  },
```

With asm implementation:

```
  "nqueens": {
    "benchmark": "nqueens",
    "cg_instructions before": 3293749025,
    "cg_instructions now": 3199172980,
    "cg_instructions ∆": "-2.9%",
    "interpreter_name": "pyro",
    "version before": "80d8286edd5f6f19db0d5177b6490b89d9133765",
    "version now": "e49774d6da690b979a5ab645f53ab31fd1debde5"
  },
```

0.3%. Not bad.