### PR TITLE
Track when the asm interpreter transitions into C++ interpreter

### DIFF
--- a/runtime/interpreter-gen-x64.cpp
+++ b/runtime/interpreter-gen-x64.cpp
@@ -118,7 +118,15 @@ const word kHandlerSizeShift = 8;
 const word kHandlerSize = 1 << kHandlerSizeShift;
 
 const Interpreter::OpcodeHandler kCppHandlers[] = {
+#if DCHECK_IS_ON()
+#define OP(name, id, handler)                                                  \
+  [](Thread* thread, word arg) {                                               \
+    EVENT(InterpreterDeopt_##name);                                            \
+    return Interpreter::handler(thread, arg);                                  \
+  },
+#else
 #define OP(name, id, handler) Interpreter::handler,
+#endif
     FOREACH_BYTECODE(OP)
 #undef OP
 };

--- a/util/probes/asm2cpp.bt
+++ b/util/probes/asm2cpp.bt
@@ -1,0 +1,4 @@
+usdt:./build/bin/python:python:InterpreterDeopt_* {
+  @interpreter_deopt[probe]++;
+}
+


### PR DESCRIPTION
We can measure which opcodes do this most frequently with bpftrace. This lets us see, for example, that we should probably implement a handler for `LOAD_ATTR_INSTANCE_SLOT_DESCR` (included in this PR).