### PR TITLE
Start a new block after FOR_ITER in compiler

### DIFF
--- a/library/compiler/pycodegen.py
+++ b/library/compiler/pycodegen.py
@@ -652,6 +652,7 @@ class CodeGenerator(ASTVisitor):
 
         self.nextBlock(start)
         self.emit("FOR_ITER", anchor)
+        self.nextBlock()
         self.visit(node.target)
         self.visit(node.body)
         self.emit("JUMP_ABSOLUTE", start)


### PR DESCRIPTION
This will be useful when adding LOAD_FAST optimization.