### PR TITLE
Use new opcode in _compiler_opcode.add_synonym

### DIFF
--- a/library/_compiler_opcode.py
+++ b/library/_compiler_opcode.py
@@ -294,7 +294,7 @@ opcode.FVS_HAVE_SPEC = 0x4
 
 def add_synonym(old, new):
     opcode.stack_effects[new] = opcode.stack_effects[old]
-    setattr(opcode, new, opcode.opmap[old])
+    setattr(opcode, new, opcode.opmap[new])
 
 
 add_synonym("BINARY_ADD", "BINARY_OP_ANAMORPHIC")


### PR DESCRIPTION
This fixes references to _compiler_opcode.opcode.SOME_OPCODE if it's a
synonym. Previously _compiler_opcode.opcode.BINARY_SUBSCR_ANAMORPHIC
would refer to BINARY_SUBSCR.
