### PR TITLE
Rewrite LOAD_ATTR __class__ to LOAD_TYPE

### DIFF
--- a/runtime/bytecode.h
+++ b/runtime/bytecode.h
@@ -137,7 +137,7 @@ namespace py {
   V(UNUSED_BYTECODE_117, 117, doInvalidBytecode)                               \
   V(UNUSED_BYTECODE_118, 118, doInvalidBytecode)                               \
   V(UNUSED_BYTECODE_119, 119, doInvalidBytecode)                               \
-  V(UNUSED_BYTECODE_120, 120, doInvalidBytecode)                               \
+  V(LOAD_TYPE, 120, doLoadType)                                                \
   V(UNUSED_BYTECODE_121, 121, doInvalidBytecode)                               \
   V(SETUP_FINALLY, 122, doSetupFinally)                                        \
   V(UNUSED_BYTECODE_123, 123, doInvalidBytecode)                               \

--- a/runtime/ic.cpp
+++ b/runtime/ic.cpp
@@ -51,6 +51,11 @@ static void insertDependencyForTypeLookupInMro(Thread* thread,
   }
 }
 
+void icUpdateDunderClass(Thread* thread, LayoutId layout_id, const Object& name,
+                         const Object& dependent) {
+  insertDependencyForTypeLookupInMro(thread, layout_id, name, dependent);
+}
+
 ICState icUpdateAttr(Thread* thread, const MutableTuple& caches, word cache,
                      LayoutId layout_id, const Object& value,
                      const Object& name, const Function& dependent) {

--- a/runtime/ic.h
+++ b/runtime/ic.h
@@ -54,6 +54,9 @@ ICState icUpdateAttr(Thread* thread, const MutableTuple& caches, word cache,
                      LayoutId layout_id, const Object& value,
                      const Object& name, const Function& dependent);
 
+void icUpdateDunderClass(Thread* thread, LayoutId layout_id, const Object& name,
+                         const Object& dependent);
+
 bool icIsCacheEmpty(const MutableTuple& caches, word cache);
 
 void icUpdateAttrModule(Thread* thread, const MutableTuple& caches, word cache,
@@ -343,6 +346,7 @@ class IcIterator {
       case LOAD_METHOD_ANAMORPHIC:
       case LOAD_METHOD_INSTANCE_FUNCTION:
       case LOAD_METHOD_POLYMORPHIC:
+      case LOAD_TYPE:
       case STORE_ATTR_INSTANCE:
       case STORE_ATTR_INSTANCE_OVERFLOW:
       case STORE_ATTR_INSTANCE_OVERFLOW_UPDATE:

--- a/runtime/interpreter.h
+++ b/runtime/interpreter.h
@@ -38,6 +38,7 @@ enum class LoadAttrKind {
   kInstanceTypeDescr,
   kModule,
   kType,
+  kDunderClass,
   kUnknown,
 };
 
@@ -463,6 +464,7 @@ class Interpreter {
   static Continue doLoadMethodInstanceFunction(Thread* thread, word arg);
   static Continue doLoadMethodPolymorphic(Thread* thread, word arg);
   static Continue doLoadName(Thread* thread, word arg);
+  static Continue doLoadType(Thread* thread, word arg);
   static Continue doPopExcept(Thread* thread, word arg);
   static Continue doPopFinally(Thread* thread, word arg);
   static Continue doRaiseVarargs(Thread* thread, word arg);

--- a/runtime/object-builtins.cpp
+++ b/runtime/object-builtins.cpp
@@ -242,7 +242,12 @@ RawObject objectGetAttributeSetLocation(Thread* thread, const Object& object,
         // We cache only function objects as a getter to simplify its usage.
         if (location_out != nullptr) {
           *location_out = *getter;
-          *kind = LoadAttrKind::kInstanceProperty;
+          if (type.hasFlag(Type::Flag::kHasObjectDunderClass) &&
+              *name == runtime->symbols()->at(ID(__class__))) {
+            *kind = LoadAttrKind::kDunderClass;
+          } else {
+            *kind = LoadAttrKind::kInstanceProperty;
+          }
         }
         return Interpreter::call1(thread, getter, object);
       }


### PR DESCRIPTION
This only works if the receiver's type has not overridden `__class__`.

Fixes #454

Add tests.
