### PR TITLE
Remove **kwargs from reversed.__new__

### DIFF
--- a/library/builtins.py
+++ b/library/builtins.py
@@ -5891,7 +5891,7 @@ class reversed(metaclass=_non_heaptype):
     def __iter__(self):
         return self
 
-    def __new__(cls, seq, **kwargs):
+    def __new__(cls, seq):
         dunder_reversed = _object_type_getattr(seq, "__reversed__")
         if dunder_reversed is None:
             raise TypeError(f"'{_type(seq).__name__}' object is not reversible")

--- a/library/builtins_test.py
+++ b/library/builtins_test.py
@@ -10216,6 +10216,16 @@ class ReversedTests(unittest.TestCase):
             reversed(C())
         self.assertEqual(str(context.exception), "'C' object is not reversible")
 
+    def test_dunder_new_with_kwargs_raises_type_error(self):
+        class C:
+            pass
+
+        with self.assertRaises(TypeError) as context:
+            reversed.__new__(reversed, [], foo=123)
+        # TODO(emacs): Make error message for unexpected keyword arguments more
+        # descriptive.
+        self.assertIn("arguments", str(context.exception))
+
     def test_reversed_iterates_backwards_over_iterable(self):
         it = reversed([1, 2, 3])
         self.assertEqual(it.__next__(), 3)


### PR DESCRIPTION
The function is not supposed to take `**kwargs`; it should raise a
`TypeError`. This also speeds up the creation of `reversed()` objects by not
allocating an empty dict with every call.

Add tests.

```json
{
  "django_minimal_requests": {
    "benchmark": "django_minimal_requests",
    "cg_instructions before": 694510,
    "cg_instructions now": 693934,
    "cg_instructions ∆": "-0.1%",
    "interpreter_args": [],
    "interpreter_name": "pyro",
    "version before": "cd35adcc708c74149e7d2f9ec197d3c1e46fed4a",
    "version now": "f88097c5045a760ab9494a43cbbe897392376cb1"
  }
}
```
