### PR TITLE
Rewrite BUILD_SLICE to LOAD_SLICE_CACHED when it's constant

### DIFF
--- a/runtime/bytecode.h
+++ b/runtime/bytecode.h
@@ -151,7 +151,7 @@ namespace py {
   V(CALL_FUNCTION, 131, doCallFunction)                                        \
   V(MAKE_FUNCTION, 132, doMakeFunction)                                        \
   V(BUILD_SLICE, 133, doBuildSlice)                                            \
-  V(UNUSED_BYTECODE_134, 134, doInvalidBytecode)                               \
+  V(LOAD_SLICE_CACHED, 134, doLoadSliceCached)                                 \
   V(LOAD_CLOSURE, 135, doLoadClosure)                                          \
   V(LOAD_DEREF, 136, doLoadDeref)                                              \
   V(STORE_DEREF, 137, doStoreDeref)                                            \
@@ -334,6 +334,7 @@ struct BytecodeOp {
   Bytecode bc;
   int32_t arg;
   uint16_t cache;
+  word index;
 };
 
 BytecodeOp nextBytecodeOp(const MutableBytes& bytecode, word* index);

--- a/runtime/interpreter-gen-x64.cpp
+++ b/runtime/interpreter-gen-x64.cpp
@@ -792,6 +792,11 @@ void emitAttrWithOffset(EmitEnv* env, void (Assembler::*asm_op)(Address),
 }
 
 template <>
+void emitHandler<NOP>(EmitEnv* env) {
+  emitNextOpcodeFallthrough(env);
+}
+
+template <>
 void emitHandler<BINARY_ADD_SMALLINT>(EmitEnv* env) {
   ScratchReg r_right(env);
   ScratchReg r_left(env);

--- a/runtime/interpreter.cpp
+++ b/runtime/interpreter.cpp
@@ -4638,6 +4638,17 @@ HANDLER_INLINE Continue Interpreter::doBuildSlice(Thread* thread, word arg) {
   return Continue::NEXT;
 }
 
+HANDLER_INLINE Continue Interpreter::doLoadSliceCached(Thread* thread, word) {
+  Frame* frame = thread->currentFrame();
+  RawMutableTuple caches = MutableTuple::cast(frame->caches());
+  word cache = currentCacheIndex(frame);
+  word index = cache * kIcPointersPerEntry;
+  RawObject slice = caches.at(index + kIcEntryValueOffset);
+  DCHECK(slice.isSlice(), "expected to have a slice in the cache");
+  thread->stackPush(slice);
+  return Continue::NEXT;
+}
+
 HANDLER_INLINE Continue Interpreter::doLoadClosure(Thread* thread, word arg) {
   Frame* frame = thread->currentFrame();
   RawCode code = Code::cast(frame->code());

--- a/runtime/interpreter.h
+++ b/runtime/interpreter.h
@@ -496,6 +496,7 @@ class Interpreter {
   static Continue doBuildConstKeyMap(Thread* thread, word arg);
   static Continue doBuildList(Thread* thread, word arg);
   static Continue doBuildSlice(Thread* thread, word arg);
+  static Continue doLoadSliceCached(Thread* thread, word arg);
   static Continue doBuildString(Thread* thread, word arg);
   static Continue doBuildTuple(Thread* thread, word arg);
   static Continue doDeleteDeref(Thread* thread, word arg);


### PR DESCRIPTION
This saves on allocations. It's a little finicky, though, since it
relies on a series of three LOAD_CONST with no EXTENDED_ARG.
