### PR TITLE
Specialize binary ops for floats

### DIFF
--- a/runtime/bytecode.h
+++ b/runtime/bytecode.h
@@ -59,8 +59,8 @@ namespace py {
   V(UNUSED_BYTECODE_39, 39, doInvalidBytecode)                                 \
   V(UNUSED_BYTECODE_40, 40, doInvalidBytecode)                                 \
   V(UNUSED_BYTECODE_41, 41, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_42, 42, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_43, 43, doInvalidBytecode)                                 \
+  V(INPLACE_ADD_FLOAT, 42, doInplaceAddFloat)                                  \
+  V(INPLACE_SUB_FLOAT, 43, doInplaceSubFloat)                                  \
   V(BINARY_ADD_FLOAT, 44, doBinaryAddFloat)                                    \
   V(BINARY_SUB_FLOAT, 45, doBinarySubFloat)                                    \
   V(BINARY_MUL_FLOAT, 46, doBinaryMulFloat)                                    \

--- a/runtime/bytecode.h
+++ b/runtime/bytecode.h
@@ -61,10 +61,10 @@ namespace py {
   V(UNUSED_BYTECODE_41, 41, doInvalidBytecode)                                 \
   V(UNUSED_BYTECODE_42, 42, doInvalidBytecode)                                 \
   V(UNUSED_BYTECODE_43, 43, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_44, 44, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_45, 45, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_46, 46, doInvalidBytecode)                                 \
-  V(UNUSED_BYTECODE_47, 47, doInvalidBytecode)                                 \
+  V(BINARY_ADD_FLOAT, 44, doBinaryAddFloat)                                    \
+  V(BINARY_SUB_FLOAT, 45, doBinarySubFloat)                                    \
+  V(BINARY_MUL_FLOAT, 46, doBinaryMulFloat)                                    \
+  V(BINARY_POWER_FLOAT, 47, doBinaryPowerFloat)                                \
   V(LOAD_BOOL, 48, doLoadBool)                                                 \
   V(UNUSED_BYTECODE_49, 49, doInvalidBytecode)                                 \
   V(GET_AITER, 50, doGetAiter)                                                 \

--- a/runtime/interpreter-gen-x64.cpp
+++ b/runtime/interpreter-gen-x64.cpp
@@ -635,8 +635,9 @@ void emitJumpIfNotHasLayoutId(EmitEnv* env, Register r_obj, LayoutId layout_id,
 }
 
 void emitJumpIfNotHeapObjectWithLayoutId(EmitEnv* env, Register r_obj,
-                                         LayoutId layout_id, Label* target) {
-  emitJumpIfImmediate(env, r_obj, target, Assembler::kNearJump);
+                                         LayoutId layout_id, Label* target,
+                                         bool is_near = Assembler::kNearJump) {
+  emitJumpIfImmediate(env, r_obj, target, is_near);
 
   // It is a HeapObject.
   emitJumpIfNotHasLayoutId(env, r_obj, layout_id, target);
@@ -733,6 +734,32 @@ void emitPushBoundMethod(EmitEnv* env, Label* slow_path, Register r_self,
   __ pushq(r_scratch);
 }
 
+// Allocate and push a Float on the stack. If the heap is full and a GC
+// is needed, jump to slow_path instead. r_value will be used to populate the
+// Float. r_space and r_scratch are used as scratch registers.
+//
+// Writes to r_space and r_scratch.
+void emitPushFloat(EmitEnv* env, Label* slow_path, XmmRegister r_value) {
+  ScratchReg r_scratch(env);
+  ScratchReg r_space(env);
+  __ movq(r_space, Address(env->thread, Thread::runtimeOffset()));
+  __ movq(r_space,
+          Address(r_space, Runtime::heapOffset() + Heap::spaceOffset()));
+
+  __ movq(r_scratch, Address(r_space, Space::fillOffset()));
+  __ addq(r_scratch, Immediate(Float::allocationSize()));
+  __ cmpq(r_scratch, Address(r_space, Space::endOffset()));
+  __ jcc(GREATER, slow_path, Assembler::kFarJump);
+  __ xchgq(r_scratch, Address(r_space, Space::fillOffset()));
+  RawHeader header = Header::from(Float::kSize, /*hash=*/0, LayoutId::kFloat,
+                                  ObjectFormat::kData);
+  __ movq(Address(r_scratch, 0), Immediate(header.raw()));
+  __ leaq(r_scratch, Address(r_scratch, -RawFloat::kHeaderOffset +
+                                            Object::kHeapObjectTag));
+  __ movsd(Address(r_scratch, heapObjectDisp(RawFloat::kValueOffset)), r_value);
+  __ pushq(r_scratch);
+}
+
 // Given a RawObject in r_obj and its LayoutId (as a SmallInt) in r_layout_id,
 // load its overflow RawTuple into r_dst.
 //
@@ -822,6 +849,34 @@ void emitHandler<BINARY_ADD_SMALLINT>(EmitEnv* env) {
   emitCall<Interpreter::Continue (*)(Thread*, word, word)>(
       env, Interpreter::binaryOpUpdateCache);
   emitHandleContinue(env, kGenericHandler);
+}
+
+template <>
+void emitHandler<BINARY_MUL_FLOAT>(EmitEnv* env) {
+  ScratchReg r_right(env);
+  ScratchReg r_left(env);
+  Label slow_path;
+
+  __ popq(r_right);
+  __ popq(r_left);
+  emitJumpIfNotHeapObjectWithLayoutId(env, r_left, LayoutId::kFloat, &slow_path,
+                                      Assembler::kFarJump);
+  emitJumpIfNotHeapObjectWithLayoutId(env, r_right, LayoutId::kFloat,
+                                      &slow_path, Assembler::kNearJump);
+  __ movsd(XMM0, Address(r_left, heapObjectDisp(Float::kValueOffset)));
+  __ movsd(XMM1, Address(r_right, heapObjectDisp(Float::kValueOffset)));
+  __ mulsd(XMM0, XMM1);
+  emitPushFloat(env, &slow_path, XMM0);
+  emitNextOpcode(env);
+
+  __ bind(&slow_path);
+  __ pushq(r_left);
+  __ pushq(r_right);
+  if (env->in_jit) {
+    emitJumpToDeopt(env);
+    return;
+  }
+  emitJumpToGenericHandler(env);
 }
 
 template <>

--- a/runtime/interpreter-gen-x64.cpp
+++ b/runtime/interpreter-gen-x64.cpp
@@ -2446,6 +2446,13 @@ void emitHandler<DUP_TOP>(EmitEnv* env) {
 }
 
 template <>
+void emitHandler<DUP_TOP_TWO>(EmitEnv* env) {
+  __ pushq(Address(RSP, kPointerSize));
+  __ pushq(Address(RSP, kPointerSize));
+  emitNextOpcodeFallthrough(env);
+}
+
+template <>
 void emitHandler<ROT_TWO>(EmitEnv* env) {
   ScratchReg r_scratch(env);
 

--- a/runtime/interpreter-gen-x64.cpp
+++ b/runtime/interpreter-gen-x64.cpp
@@ -2458,7 +2458,22 @@ void emitHandler<ROT_TWO>(EmitEnv* env) {
 
   __ popq(r_scratch);
   __ pushq(Address(RSP, 0));
-  __ movq(Address(RSP, 8), r_scratch);
+  __ movq(Address(RSP, kPointerSize), r_scratch);
+  emitNextOpcodeFallthrough(env);
+}
+
+template <>
+void emitHandler<ROT_THREE>(EmitEnv* env) {
+  ScratchReg r_top(env);
+  ScratchReg r_second(env);
+  ScratchReg r_third(env);
+
+  __ popq(r_top);
+  __ popq(r_second);
+  __ popq(r_third);
+  __ pushq(r_top);
+  __ pushq(r_third);
+  __ pushq(r_second);
   emitNextOpcodeFallthrough(env);
 }
 

--- a/runtime/interpreter.h
+++ b/runtime/interpreter.h
@@ -437,6 +437,7 @@ class Interpreter {
   static Continue doImportName(Thread* thread, word arg);
   static Continue doInplaceAdd(Thread* thread, word arg);
   static Continue doInplaceAddSmallInt(Thread* thread, word arg);
+  static Continue doInplaceAddFloat(Thread* thread, word arg);
   static Continue doInplaceAnd(Thread* thread, word arg);
   static Continue doInplaceFloorDivide(Thread* thread, word arg);
   static Continue doInplaceLshift(Thread* thread, word arg);
@@ -451,6 +452,7 @@ class Interpreter {
   static Continue doInplaceRshift(Thread* thread, word arg);
   static Continue doInplaceSubtract(Thread* thread, word arg);
   static Continue doInplaceSubSmallInt(Thread* thread, word arg);
+  static Continue doInplaceSubFloat(Thread* thread, word arg);
   static Continue doInplaceTrueDivide(Thread* thread, word arg);
   static Continue doInplaceXor(Thread* thread, word arg);
   static Continue doInvalidBytecode(Thread* thread, word arg);

--- a/runtime/interpreter.h
+++ b/runtime/interpreter.h
@@ -360,6 +360,10 @@ class Interpreter {
   static Continue doBinarySubSmallInt(Thread* thread, word arg);
   static Continue doBinaryOrSmallInt(Thread* thread, word arg);
   static Continue doBinaryOpAnamorphic(Thread* thread, word arg);
+  static Continue doBinaryAddFloat(Thread* thread, word arg);
+  static Continue doBinarySubFloat(Thread* thread, word arg);
+  static Continue doBinaryMulFloat(Thread* thread, word arg);
+  static Continue doBinaryPowerFloat(Thread* thread, word arg);
   static Continue doBinaryOr(Thread* thread, word arg);
   static Continue doBinaryPower(Thread* thread, word arg);
   static Continue doBinaryRshift(Thread* thread, word arg);


### PR DESCRIPTION
- Add BINARY_{ADD,SUB,MUL,POWER}_FLOAT specializations in interpreter
- Add asm interpreter implementation of DUP_TOP_TWO
- Add asm interpreter implementation of ROT_THREE
- Add INPLACE_{ADD,SUB}_FLOAT specializations in interpreter
- Add asm interpreter implementation of BINARY_MUL_FLOAT
- Add the other ops; they are very similar
