### PR TITLE
Add Type::Flag::kIsStructseq and specialize unpacking of structseqs

### DIFF
--- a/ext/Objects/structseq.cpp
+++ b/ext/Objects/structseq.cpp
@@ -77,7 +77,7 @@ PY_EXPORT PyTypeObject* PyStructSequence_NewType(PyStructSequence_Desc* desc) {
   }
   Tuple field_names_tuple(&scope, field_names.becomeImmutable());
   Str name(&scope, runtime->newStrFromCStr(desc->name));
-  word flags = Type::Flag::kIsCPythonHeaptype;
+  word flags = Type::Flag::kIsCPythonHeaptype | Type::Flag::kIsStructseq;
   Object result(&scope, structseqNewType(thread, name, field_names_tuple,
                                          desc->n_in_sequence, flags));
   if (result.isErrorException()) return nullptr;

--- a/runtime/interpreter.cpp
+++ b/runtime/interpreter.cpp
@@ -2810,6 +2810,10 @@ HANDLER_INLINE USED RawObject Interpreter::unpackSequence(Thread* thread,
   } else if (iterable.isList()) {
     count = List::cast(iterable).numItems();
     iterable = List::cast(iterable).items();
+  } else if (thread->runtime()->typeOf(iterable).hasFlag(
+                 Type::Flag::kIsStructseq)) {
+    iterable = Tuple::cast(iterable.rawCast<RawUserTupleBase>().value());
+    count = Tuple::cast(iterable).length();
   } else {
     return unpackSequenceIterable(thread, length, iterable);
   }

--- a/runtime/objects.h
+++ b/runtime/objects.h
@@ -1286,6 +1286,9 @@ class RawType : public RawAttributeDict {
 
     // this_type.__eq__ is object.__eq__.
     kHasObjectDunderEq = 1 << 30,
+
+    // this_type is a structseq (and not a subclass thereof)
+    kIsStructseq = 1 << 31,
   };
 
   static const word kAttributeFlags =
@@ -1296,9 +1299,9 @@ class RawType : public RawAttributeDict {
       Flag::kHasDunderGet | Flag::kHasDunderSet | Flag::kHasDunderDelete |
       Flag::kHasObjectDunderEq;
 
-  static const word kUninheritableFlags = Flag::kIsAbstract |
-                                          Flag::kIsFixedAttributeBase |
-                                          Flag::kIsBasetype | kAttributeFlags;
+  static const word kUninheritableFlags =
+      Flag::kIsAbstract | Flag::kIsFixedAttributeBase | Flag::kIsBasetype |
+      kAttributeFlags | kIsStructseq;
 
   static const word kInheritableFlags = ~kUninheritableFlags;
 

--- a/runtime/under-builtins-module.cpp
+++ b/runtime/under-builtins-module.cpp
@@ -4758,6 +4758,7 @@ RawObject FUNC(_builtins, _structseq_new_type)(Thread* thread, Arguments args) {
                              : SmallInt::cast(args.get(3)).value();
   word flags =
       is_heaptype.value() ? Type::Flag::kIsCPythonHeaptype : Type::Flag::kNone;
+  flags |= Type::Flag::kIsStructseq;
   return structseqNewType(thread, name, field_names, num_in_sequence, flags);
 }
 


### PR DESCRIPTION
They are tuple subclasses and this is fairly straightforward. The only
surprising thing is that they only unpack the in-sequence attributes,
not the in-object ones.

Add tests.

Fixes #474