### PR TITLE
Revert "change an instance of deque back to list in benchmark"

### DIFF
--- a/benchmarks/benchmarks/go.py
+++ b/benchmarks/benchmarks/go.py
@@ -328,7 +328,7 @@ class UCTNode:
         self.pos = -1
         self.wins = 0
         self.losses = 0
-        self.pos_child = [None for x in range(SIZE * SIZE)]
+        self.pos_child = collections.deque([None for x in range(SIZE * SIZE)])
         self.parent = None
 
     def play(self, board):


### PR DESCRIPTION
This reverts commit a23d3a08d5450c5c3dd07a9a9f2b1b0cb378b037.
`collections.deque` now has `__setitem__`. They were implemented in
D25245335 (fafcc34f308645af90fef67da51573b44f31f004).
