### PR TITLE
Get simple setuptools setup.py working

### DIFF
--- a/library/builtins.py
+++ b/library/builtins.py
@@ -1031,8 +1031,8 @@ class ImportError(Exception, bootstrap=True):
         self.args = args
         if len(args) == 1:
             self.msg = args[0]
-        self.name = name
-        self.path = path
+        _instance_setattr(self, "name", name)
+        _instance_setattr(self, "path", path)
 
     def __reduce__(self):
         _unimplemented()

--- a/library/builtins.py
+++ b/library/builtins.py
@@ -4343,10 +4343,13 @@ class instance_proxy(bootstrap=True):
         _instance_guard(instance)
         return {key: _instance_getattr(instance, key) for key in _object_keys(instance)}
 
-    def update(self, d):
+    def update(self, d=_Unbound, /, **kwargs):
         instance = self._instance
         _instance_guard(instance)
-        for key, value in d.items():
+        if d is not _Unbound:
+            for key, value in d.items():
+                _instance_setattr(instance, key, value)
+        for key, value in kwargs.items():
             _instance_setattr(instance, key, value)
 
     def get(self, key, default=None):

--- a/library/builtins_test.py
+++ b/library/builtins_test.py
@@ -4944,6 +4944,32 @@ class ExceptionTests(unittest.TestCase):
         exc = SystemExit(1111)
         self.assertEqual(exc.code, 1111)
 
+    def test_set_name_attr_on_import_error_subclass_with_property_sets_attr(self):
+        class C(ModuleNotFoundError):
+            # Modeled after PackageNotFoundError in
+            # importlib_metadata/__init__.py
+            @property
+            def name(self):
+                (name,) = self.args
+                return name
+
+        c = C("a name")
+        self.assertEqual(c.name, "a name")
+        self.assertEqual(c.path, None)
+
+    def test_set_path_attr_on_import_error_subclass_with_property_sets_attr(self):
+        class C(ModuleNotFoundError):
+            # Modeled after PackageNotFoundError in
+            # importlib_metadata/__init__.py
+            @property
+            def path(self):
+                (path,) = self.args
+                return path
+
+        c = C("a path")
+        self.assertEqual(c.name, None)
+        self.assertEqual(c.path, "a path")
+
 
 class EvalTests(unittest.TestCase):
     def test_globals_none_accesses_function_globals(self):

--- a/library/builtins_test.py
+++ b/library/builtins_test.py
@@ -6898,6 +6898,30 @@ class InstanceTests(unittest.TestCase):
         instance.__dict__ = {"hello": "world"}
         self.assertEqual(list(instance.__dict__.keys()), ["hello"])
 
+    def test_vars_update_with_no_args_does_not_raise(self):
+        class C:
+            pass
+
+        instance = C()
+        vars(instance).update()
+
+    def test_vars_update_with_only_kwargs_sets_attribute(self):
+        class C:
+            pass
+
+        instance = C()
+        vars(instance).update(hello=1)
+        self.assertEqual(instance.hello, 1)
+
+    def test_vars_update_with_args_and_kwargs_sets_attributes(self):
+        class C:
+            pass
+
+        instance = C()
+        vars(instance).update({"hello": 1}, world=2)
+        self.assertEqual(instance.hello, 1)
+        self.assertEqual(instance.world, 2)
+
 
 class IsInstanceTests(unittest.TestCase):
     def test_isinstance_with_same_types_returns_true(self):


### PR DESCRIPTION
Woooo! Let's go!

```console?prompt=cedar%
cedar% ~/Documents/code/skybison/build-relwithdebinfo/bin/python setup.py build_ext --inplace 
running build_ext
building 'signature' extension
creating build
creating build/temp.linux-x86_64-skybison-38
gcc -Wno-unused-result -Wsign-compare -g -Og -Wall -fPIC -I/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8 -I/home/max/Documents/code/skybison/build-relwithdebinfo/include/python3.8 -c signature.c -o build/temp.linux-x86_64-skybison-38/signature.o -std=c99 -Wall -Wextra
In file included from /home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-data.h:5,
                 from /home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/Python.h:15,
                 from signature.c:1:
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1306:58: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
 1306 | PyAPI_FUNC_DECL(int _PyTime_AsTimespec(_PyTime_t, struct timespec*));
      |                                                          ^~~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:16:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   16 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1307:57: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1307 | PyAPI_FUNC_DECL(int _PyTime_AsTimeval(_PyTime_t, struct timeval*,
      |                                                         ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:16:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   16 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1311:65: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1311 | PyAPI_FUNC_DECL(int _PyTime_AsTimeval_noraise(_PyTime_t, struct timeval*,
      |                                                                 ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:16:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   16 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1320:64: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
 1320 | PyAPI_FUNC_DECL(int _PyTime_FromTimespec(_PyTime_t* tp, struct timespec* ts));
      |                                                                ^~~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:16:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   16 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1321:63: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1321 | PyAPI_FUNC_DECL(int _PyTime_FromTimeval(_PyTime_t* tp, struct timeval* tv));
      |                                                               ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:16:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   16 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
creating build/lib.linux-x86_64-skybison-38
gcc -pthread -shared build/temp.linux-x86_64-skybison-38/signature.o -o build/lib.linux-x86_64-skybison-38/signature.pyro.so
copying build/lib.linux-x86_64-skybison-38/signature.pyro.so -> 
cedar%
```