### PR TITLE
Fix timespec/timeval warning when compiling C extension modules

### DIFF
--- a/capi/cpython-types.h
+++ b/capi/cpython-types.h
@@ -430,6 +430,8 @@ typedef void (*PyCapsule_Destructor)(PyObject*);
 typedef PyObject* (*Py_OpenCodeHookFunction)(PyObject*, void*);
 typedef int (*Py_tracefunc)(PyObject*, PyFrameObject*, int, PyObject*);
 
+struct timespec;
+struct timeval;
 typedef int64_t _PyTime_t;
 #define _PyTime_MIN INT64_MIN
 #define _PyTime_MAX INT64_MAX


### PR DESCRIPTION
On some compilers, the warnings below get generated. I think it's
something to do with not defining `_POSIX_C_SOURCE` when we include
`time.h` but that didn't work--so it might be a project-level setting
that we need to tweak.

In the meantime, forward declare the structs in `cpython-types.h`.

```
In file included from /home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-data.h:5,
                 from /home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/Python.h:15,
                 from signature.c:1:
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1311:58: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
 1311 | PyAPI_FUNC_DECL(int _PyTime_AsTimespec(_PyTime_t, struct timespec*));
      |                                                          ^~~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:21:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   21 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1312:57: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1312 | PyAPI_FUNC_DECL(int _PyTime_AsTimeval(_PyTime_t, struct timeval*,
      |                                                         ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:21:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   21 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1316:65: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1316 | PyAPI_FUNC_DECL(int _PyTime_AsTimeval_noraise(_PyTime_t, struct timeval*,
      |                                                                 ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:21:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   21 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1325:64: warning: ‘struct timespec’ declared inside parameter list will not be visible outside of this definition or declaration
 1325 | PyAPI_FUNC_DECL(int _PyTime_FromTimespec(_PyTime_t* tp, struct timespec* ts));
      |                                                                ^~~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:21:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   21 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:1326:63: warning: ‘struct timeval’ declared inside parameter list will not be visible outside of this definition or declaration
 1326 | PyAPI_FUNC_DECL(int _PyTime_FromTimeval(_PyTime_t* tp, struct timeval* tv));
      |                                                               ^~~~~~~
/home/max/Documents/code/skybison/build-relwithdebinfo/include/skybison3.8/cpython-func.h:21:70: note: in definition of macro ‘PyAPI_FUNC_DECL’
   21 | #define PyAPI_FUNC_DECL(DECL) __attribute__((visibility("default"))) DECL
      |                                                                      ^~~~
```